### PR TITLE
feat: add posts api resource with media

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Exceptions;
+
+use App\Http\Responses\ApiResponse;
+use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use Illuminate\Validation\ValidationException;
+use Throwable;
+
+class Handler extends ExceptionHandler
+{
+    public function register(): void
+    {
+        $this->renderable(function (ValidationException $e) {
+            return ApiResponse::fromValidationException($e);
+        });
+    }
+}

--- a/app/Http/Controllers/Api/PostController.php
+++ b/app/Http/Controllers/Api/PostController.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\StorePostRequest;
+use App\Http\Requests\UpdatePostRequest;
+use App\Http\Resources\PostResource;
+use App\Http\Responses\ApiResponse;
+use App\Models\Post;
+use App\Services\PostService;
+use Illuminate\Http\Request;
+
+class PostController extends Controller
+{
+    public function __construct(protected PostService $service)
+    {
+    }
+
+    public function index(Request $request)
+    {
+        $posts = Post::paginate();
+        return ApiResponse::ok(PostResource::collection($posts));
+    }
+
+    public function store(StorePostRequest $request)
+    {
+        $data = $request->validated();
+        $cover = $request->file('cover');
+        unset($data['cover']);
+
+        $post = $this->service->create($data, $cover);
+
+        return ApiResponse::created(new PostResource($post));
+    }
+
+    public function show(Post $post)
+    {
+        return ApiResponse::ok(new PostResource($post));
+    }
+
+    public function update(UpdatePostRequest $request, Post $post)
+    {
+        $data = $request->validated();
+        $cover = $request->file('cover');
+        unset($data['cover']);
+
+        $post = $this->service->update($post, $data, $cover);
+
+        return ApiResponse::ok(new PostResource($post));
+    }
+
+    public function destroy(Post $post)
+    {
+        $this->service->delete($post);
+        return ApiResponse::noContent();
+    }
+}

--- a/app/Http/Requests/StorePostRequest.php
+++ b/app/Http/Requests/StorePostRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StorePostRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'user_id' => ['required', 'exists:users,id'],
+            'title' => ['required', 'string', 'max:255'],
+            'slug' => ['required', 'string', 'max:255', 'unique:posts,slug'],
+            'excerpt' => ['nullable', 'string'],
+            'description' => ['required', 'string'],
+            'location' => ['nullable', 'string', 'max:255'],
+            'starts_at' => ['nullable', 'date'],
+            'ends_at' => ['nullable', 'date', 'after_or_equal:starts_at'],
+            'is_published' => ['boolean'],
+            'published_at' => ['nullable', 'date'],
+            'cover' => ['nullable', 'image', 'max:2048'],
+        ];
+    }
+}

--- a/app/Http/Requests/UpdatePostRequest.php
+++ b/app/Http/Requests/UpdatePostRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdatePostRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'user_id' => ['sometimes', 'exists:users,id'],
+            'title' => ['sometimes', 'string', 'max:255'],
+            'slug' => ['sometimes', 'string', 'max:255', Rule::unique('posts', 'slug')->ignore($this->post)],
+            'excerpt' => ['nullable', 'string'],
+            'description' => ['sometimes', 'string'],
+            'location' => ['nullable', 'string', 'max:255'],
+            'starts_at' => ['nullable', 'date'],
+            'ends_at' => ['nullable', 'date', 'after_or_equal:starts_at'],
+            'is_published' => ['boolean'],
+            'published_at' => ['nullable', 'date'],
+            'cover' => ['nullable', 'image', 'max:2048'],
+        ];
+    }
+}

--- a/app/Http/Resources/PostResource.php
+++ b/app/Http/Resources/PostResource.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class PostResource extends JsonResource
+{
+    public static $wrap = null;
+
+    public function toArray($request): array
+    {
+        $data = [
+            'id' => $this->id,
+            'user_id' => $this->user_id,
+            'title' => $this->title,
+            'slug' => $this->slug,
+            'excerpt' => $this->excerpt,
+            'description' => $this->description,
+            'location' => $this->location,
+            'starts_at' => $this->starts_at?->toIso8601String(),
+            'ends_at' => $this->ends_at?->toIso8601String(),
+            'is_published' => $this->is_published,
+            'published_at' => $this->published_at?->toIso8601String(),
+            'created_at' => $this->created_at?->toIso8601String(),
+            'updated_at' => $this->updated_at?->toIso8601String(),
+            'cover_url' => $this->getFirstMediaUrl('cover'),
+        ];
+
+        if ($fields = $request->query('fields')) {
+            $fields = array_map('trim', explode(',', $fields));
+            $data = array_intersect_key($data, array_flip($fields));
+        }
+
+        return $data;
+    }
+}

--- a/app/Http/Responses/ApiResponse.php
+++ b/app/Http/Responses/ApiResponse.php
@@ -43,4 +43,9 @@ class ApiResponse implements Responsable
         $data = is_null($errors) ? null : ['errors' => $errors];
         return new static($data, $msg, $status);
     }
+
+    public static function fromValidationException(\Illuminate\Validation\ValidationException $e): static
+    {
+        return self::error(__('validation.failed'), $e->status, $e->errors());
+    }
 }

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Spatie\MediaLibrary\HasMedia;
+use Spatie\MediaLibrary\InteractsWithMedia;
+
+class Post extends Model implements HasMedia
+{
+    use HasFactory, SoftDeletes, InteractsWithMedia;
+
+    protected $fillable = [
+        'user_id',
+        'title',
+        'slug',
+        'excerpt',
+        'description',
+        'location',
+        'starts_at',
+        'ends_at',
+        'is_published',
+        'published_at',
+    ];
+
+    protected $casts = [
+        'starts_at' => 'datetime',
+        'ends_at' => 'datetime',
+        'is_published' => 'boolean',
+        'published_at' => 'datetime',
+    ];
+
+    public function registerMediaCollections(): void
+    {
+        $this->addMediaCollection('cover')->singleFile();
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Policies/PostPolicy.php
+++ b/app/Policies/PostPolicy.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Post;
+use App\Models\User;
+
+class PostPolicy
+{
+    public function update(User $user, Post $post): bool
+    {
+        return $user->id === $post->user_id;
+    }
+
+    public function delete(User $user, Post $post): bool
+    {
+        return $user->id === $post->user_id;
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Providers;
+
+use App\Models\Post;
+use App\Policies\PostPolicy;
+use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
+
+class AuthServiceProvider extends ServiceProvider
+{
+    protected $policies = [
+        Post::class => PostPolicy::class,
+    ];
+
+    public function boot(): void
+    {
+        $this->registerPolicies();
+    }
+}

--- a/app/Services/PostService.php
+++ b/app/Services/PostService.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Post;
+use Illuminate\Http\UploadedFile;
+
+class PostService
+{
+    public function create(array $data, ?UploadedFile $cover = null): Post
+    {
+        $post = Post::create($data);
+
+        if ($cover) {
+            $post->addMedia($cover)->toMediaCollection('cover');
+        }
+
+        return $post;
+    }
+
+    public function update(Post $post, array $data, ?UploadedFile $cover = null): Post
+    {
+        $post->update($data);
+
+        if ($cover) {
+            $post->clearMediaCollection('cover');
+            $post->addMedia($cover)->toMediaCollection('cover');
+        }
+
+        return $post;
+    }
+
+    public function delete(Post $post): void
+    {
+        $post->delete();
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -3,10 +3,13 @@
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use Illuminate\Validation\ValidationException;
+use App\Http\Responses\ApiResponse;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )
@@ -14,5 +17,7 @@ return Application::configure(basePath: dirname(__DIR__))
         //
     })
     ->withExceptions(function (Exceptions $exceptions): void {
-        //
+        $exceptions->render(function (ValidationException $e) {
+            return ApiResponse::fromValidationException($e);
+        });
     })->create();

--- a/database/factories/PostFactory.php
+++ b/database/factories/PostFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Post;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Post>
+ */
+class PostFactory extends Factory
+{
+    protected $model = Post::class;
+
+    public function definition(): array
+    {
+        $title = $this->faker->sentence();
+        return [
+            'user_id' => User::factory(),
+            'title' => $title,
+            'slug' => Str::slug($title) . '-' . Str::random(5),
+            'excerpt' => $this->faker->paragraph(),
+            'description' => $this->faker->paragraphs(3, true),
+            'location' => $this->faker->city(),
+            'starts_at' => $this->faker->dateTimeBetween('-1 week', '+1 week'),
+            'ends_at' => $this->faker->dateTimeBetween('+1 week', '+2 weeks'),
+            'is_published' => true,
+            'published_at' => now(),
+        ];
+    }
+}

--- a/database/migrations/0001_01_01_000003_create_posts_table.php
+++ b/database/migrations/0001_01_01_000003_create_posts_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('posts', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('title');
+            $table->string('slug')->unique();
+            $table->text('excerpt')->nullable();
+            $table->longText('description');
+            $table->string('location')->nullable();
+            $table->timestamp('starts_at')->nullable()->index();
+            $table->timestamp('ends_at')->nullable()->index();
+            $table->boolean('is_published')->default(false)->index();
+            $table->timestamp('published_at')->nullable()->index();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('posts');
+    }
+};

--- a/database/seeders/PostSeeder.php
+++ b/database/seeders/PostSeeder.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Post;
+use Illuminate\Database\Seeder;
+
+class PostSeeder extends Seeder
+{
+    public function run(): void
+    {
+        Post::factory()->count(10)->create();
+    }
+}

--- a/postman/posts.postman_collection.json
+++ b/postman/posts.postman_collection.json
@@ -1,0 +1,72 @@
+{
+  "info": {
+    "name": "Posts API",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    {"key": "baseUrl", "value": "http://localhost:8000/api"}
+  ],
+  "item": [
+    {
+      "name": "List Posts",
+      "request": {
+        "method": "GET",
+        "url": "{{baseUrl}}/v1/posts"
+      }
+    },
+    {
+      "name": "Create Post",
+      "request": {
+        "method": "POST",
+        "header": [
+          {"key": "Accept", "value": "application/json"}
+        ],
+        "body": {
+          "mode": "formdata",
+          "formdata": [
+            {"key": "user_id", "value": "1"},
+            {"key": "title", "value": "Sample"},
+            {"key": "slug", "value": "sample"},
+            {"key": "description", "value": "Desc"},
+            {"key": "cover", "type": "file", "src": ""}
+          ]
+        },
+        "url": "{{baseUrl}}/v1/posts"
+      }
+    },
+    {
+      "name": "Show Post",
+      "request": {
+        "method": "GET",
+        "url": "{{baseUrl}}/v1/posts/1"
+      }
+    },
+    {
+      "name": "Update Post",
+      "request": {
+        "method": "POST",
+        "header": [
+          {"key": "Accept", "value": "application/json"},
+          {"key": "X-HTTP-Method-Override", "value": "PUT"}
+        ],
+        "body": {
+          "mode": "formdata",
+          "formdata": [
+            {"key": "title", "value": "Updated"}
+          ]
+        },
+        "url": "{{baseUrl}}/v1/posts/1"
+      }
+    },
+    {
+      "name": "Delete Post",
+      "request": {
+        "method": "DELETE",
+        "header": [
+          {"key": "Accept", "value": "application/json"}
+        ],
+        "url": "{{baseUrl}}/v1/posts/1"
+      }
+    }
+  ]
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,8 @@
+<?php
+
+use App\Http\Controllers\Api\PostController;
+use Illuminate\Support\Facades\Route;
+
+Route::prefix('v1')->group(function () {
+    Route::apiResource('posts', PostController::class);
+});

--- a/tests/Feature/PostTest.php
+++ b/tests/Feature/PostTest.php
@@ -1,0 +1,33 @@
+<?php
+
+use App\Models\Post;
+use App\Models\User;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use function Pest\Laravel\{getJson, post, put};
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+});
+
+test('can list posts', function () {
+    Post::factory()->count(2)->create(['user_id' => $this->user->id]);
+
+    $response = getJson('/api/v1/posts');
+    $response->assertOk()->assertJsonStructure(['data']);
+});
+
+test('can create post with cover upload', function () {
+    Storage::fake('public');
+
+    $response = post('/api/v1/posts', [
+        'user_id' => $this->user->id,
+        'title' => 'Test Post',
+        'slug' => 'test-post',
+        'description' => 'Body',
+        'cover' => UploadedFile::fake()->image('cover.jpg'),
+    ], ['Accept' => 'application/json']);
+
+    $response->assertCreated();
+    expect(Post::first()->getFirstMediaUrl('cover'))->not->toBeEmpty();
+});


### PR DESCRIPTION
## Summary
- add Post model, migration, factory, service, policy, routes and controller
- integrate Spatie Media Library and API resource
- add validation exception handling and Postman collection

## Testing
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_b_68a1c405aa2c8320af6b475ff70001a7