### PR TITLE
Refactor Post resource for Filament v4

### DIFF
--- a/app/Filament/Resources/PostResource.php
+++ b/app/Filament/Resources/PostResource.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\PostResource\Pages;
+use App\Filament\Resources\PostResource\Schemas\PostForm;
+use App\Filament\Resources\PostResource\Tables\PostsTable;
+use App\Models\Post;
+use BackedEnum;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Table;
+
+class PostResource extends Resource
+{
+    protected static ?string $model = Post::class;
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedDocumentText;
+
+    public static function form(Schema $schema): Schema
+    {
+        return PostForm::configure($schema);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return PostsTable::configure($table);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListPosts::route('/'),
+            'create' => Pages\CreatePost::route('/create'),
+            'edit' => Pages\EditPost::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/PostResource/Pages/CreatePost.php
+++ b/app/Filament/Resources/PostResource/Pages/CreatePost.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Filament\Resources\PostResource\Pages;
+
+use App\Filament\Resources\PostResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreatePost extends CreateRecord
+{
+    protected static string $resource = PostResource::class;
+}
+

--- a/app/Filament/Resources/PostResource/Pages/EditPost.php
+++ b/app/Filament/Resources/PostResource/Pages/EditPost.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\PostResource\Pages;
+
+use App\Filament\Resources\PostResource;
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+
+class EditPost extends EditRecord
+{
+    protected static string $resource = PostResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/PostResource/Pages/ListPosts.php
+++ b/app/Filament/Resources/PostResource/Pages/ListPosts.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\PostResource\Pages;
+
+use App\Filament\Resources\PostResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListPosts extends ListRecords
+{
+    protected static string $resource = PostResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/PostResource/Schemas/PostForm.php
+++ b/app/Filament/Resources/PostResource/Schemas/PostForm.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Filament\Resources\PostResource\Schemas;
+
+use Filament\Forms\Components\DateTimePicker;
+use Filament\Forms\Components\RichEditor;
+use Filament\Forms\Components\SpatieMediaLibraryFileUpload;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\Toggle;
+use Filament\Schemas\Schema;
+
+class PostForm
+{
+    public static function configure(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                TextInput::make('title')
+                    ->required()
+                    ->maxLength(255),
+                TextInput::make('slug')
+                    ->required()
+                    ->unique(ignoreRecord: true)
+                    ->maxLength(255),
+                Textarea::make('excerpt')
+                    ->maxLength(65535)
+                    ->columnSpanFull(),
+                RichEditor::make('description')
+                    ->columnSpanFull(),
+                TextInput::make('location')
+                    ->maxLength(255),
+                DateTimePicker::make('starts_at'),
+                DateTimePicker::make('ends_at'),
+                Toggle::make('is_published')
+                    ->label('Published'),
+                DateTimePicker::make('published_at'),
+                SpatieMediaLibraryFileUpload::make('cover')
+                    ->collection('cover')
+                    ->image()
+                    ->imageEditor()
+                    ->columnSpanFull(),
+            ]);
+    }
+}

--- a/app/Filament/Resources/PostResource/Tables/PostsTable.php
+++ b/app/Filament/Resources/PostResource/Tables/PostsTable.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Filament\Resources\PostResource\Tables;
+
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Tables\Columns\IconColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+class PostsTable
+{
+    public static function configure(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('title')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('user.name')
+                    ->label('Author')
+                    ->sortable(),
+                IconColumn::make('is_published')
+                    ->label('Published')
+                    ->boolean(),
+                TextColumn::make('published_at')
+                    ->dateTime()
+                    ->sortable(),
+                TextColumn::make('created_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+                //
+            ])
+            ->recordActions([
+                EditAction::make(),
+                DeleteAction::make(),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+}


### PR DESCRIPTION
## Summary
- refactor Post resource using Filament v4 schemas and tables
- extract form and table logic into dedicated classes
- switch navigation icon to Heroicon enum

## Testing
- `composer test` *(fails: Call to undefined function beforeEach())*

------
https://chatgpt.com/codex/tasks/task_b_68a1c8742e288320bed091c216672f24